### PR TITLE
Use /:entity_type URLs instead of a single /entity endpoint

### DIFF
--- a/bbws/__init__.py
+++ b/bbws/__init__.py
@@ -76,14 +76,19 @@ def create_app(config_file):
     bbws.custom.init(app)
 
     # Initialize webservice routes
-    import bbws.entity
+    import bbws.creator
+    import bbws.publication
+    import bbws.edition
+    import bbws.publisher
+    import bbws.work
     import bbws.revision
     import bbws.user
     import bbws.entityspecific
     import bbws.relationship
     import bbws.musicbrainz
 
-    bbws.entity.create_views(api)
+    bbws.creator.create_views(api)
+    bbws.publication.create_views(api)
     bbws.revision.create_views(api)
     bbws.user.create_views(api)
     bbws.entityspecific.create_views(api)

--- a/bbws/creator.py
+++ b/bbws/creator.py
@@ -1,0 +1,62 @@
+# -*- coding: utf8 -*-
+
+# Copyright (C) 2015 Sean Burke
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+""" This module contains the definitions for generic entity and entity-related
+resources.
+"""
+
+from bbschema import Creator
+
+from . import structures
+from .entity import (EntityResource, EntityAliasResource,
+                     EntityDisambiguationResource, EntityAnnotationResource,
+                     EntityResourceList)
+
+class CreatorResource(EntityResource):
+    entity_class = Creator
+    entity_fields = structures.creator
+    entity_data_fields = structures.creator_data
+
+
+class CreatorResourceList(EntityResourceList):
+    entity_class = Creator
+    entity_list_fields = structures.creator_list
+
+
+def create_views(api):
+    api.add_resource(CreatorResource, '/creator/<string:entity_gid>',
+                     endpoint='creator_get_single')
+
+    api.add_resource(
+        EntityAliasResource, '/creator/<string:entity_gid>/aliases',
+        endpoint='creator_get_aliases'
+    )
+
+    api.add_resource(
+        EntityDisambiguationResource,
+        '/creator/<string:entity_gid>/disambiguation',
+        endpoint='creator_get_disambiguation'
+    )
+
+    api.add_resource(
+        EntityAnnotationResource, '/creator/<string:entity_gid>/annotation',
+        endpoint='creator_get_annotation'
+    )
+
+    api.add_resource(CreatorResourceList, '/creator')

--- a/bbws/edition.py
+++ b/bbws/edition.py
@@ -1,0 +1,62 @@
+# -*- coding: utf8 -*-
+
+# Copyright (C) 2015 Sean Burke
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+""" This module contains the definitions for generic entity and entity-related
+resources.
+"""
+
+from bbschema import Edition
+
+from . import structures
+from .entity import (EntityResource, EntityAliasResource,
+                     EntityDisambiguationResource, EntityAnnotationResource,
+                     EntityResourceList)
+
+class EditionResource(EntityResource):
+    entity_class = Edition
+    entity_fields = structures.edition
+    entity_data_fields = structures.edition_data
+
+
+class EditionResourceList(EntityResourceList):
+    entity_class = Edition
+    entity_list_fields = structures.edition_list
+
+
+def create_views(api):
+    api.add_resource(EditionResource, '/edition/<string:entity_gid>',
+                     endpoint='edition_get_single')
+
+    api.add_resource(
+        EntityAliasResource, '/edition/<string:entity_gid>/aliases',
+        endpoint='edition_get_aliases'
+    )
+
+    api.add_resource(
+        EntityDisambiguationResource,
+        '/edition/<string:entity_gid>/disambiguation',
+        endpoint='edition_get_disambiguation'
+    )
+
+    api.add_resource(
+        EntityAnnotationResource, '/edition/<string:entity_gid>/annotation',
+        endpoint='edition_get_annotation'
+    )
+
+    api.add_resource(EditionResourceList, '/edition')

--- a/bbws/publication.py
+++ b/bbws/publication.py
@@ -1,0 +1,62 @@
+# -*- coding: utf8 -*-
+
+# Copyright (C) 2015 Sean Burke
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+""" This module contains the definitions for generic entity and entity-related
+resources.
+"""
+
+from bbschema import Publication
+
+from . import structures
+from .entity import (EntityResource, EntityAliasResource,
+                     EntityDisambiguationResource, EntityAnnotationResource,
+                     EntityResourceList)
+
+class PublicationResource(EntityResource):
+    entity_class = Publication
+    entity_fields = structures.publication
+    entity_data_fields = structures.publication_data
+
+
+class PublicationResourceList(EntityResourceList):
+    entity_class = Publication
+    entity_list_fields = structures.publication_list
+
+
+def create_views(api):
+    api.add_resource(PublicationResource, '/publication/<string:entity_gid>',
+                     endpoint='publication_get_single')
+
+    api.add_resource(
+        EntityAliasResource, '/publication/<string:entity_gid>/aliases',
+        endpoint='publication_get_aliases'
+    )
+
+    api.add_resource(
+        EntityDisambiguationResource,
+        '/publication/<string:entity_gid>/disambiguation',
+        endpoint='publication_get_disambiguation'
+    )
+
+    api.add_resource(
+        EntityAnnotationResource, '/publication/<string:entity_gid>/annotation',
+        endpoint='publication_get_annotation'
+    )
+
+    api.add_resource(PublicationResourceList, '/publication')

--- a/bbws/publisher.py
+++ b/bbws/publisher.py
@@ -1,0 +1,62 @@
+# -*- coding: utf8 -*-
+
+# Copyright (C) 2015 Sean Burke
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+""" This module contains the definitions for generic entity and entity-related
+resources.
+"""
+
+from bbschema import Publisher
+
+from . import structures
+from .entity import (EntityResource, EntityAliasResource,
+                     EntityDisambiguationResource, EntityAnnotationResource,
+                     EntityResourceList)
+
+class PublisherResource(EntityResource):
+    entity_class = Publisher
+    entity_fields = structures.publisher
+    entity_data_fields = structures.publisher_data
+
+
+class PublisherResourceList(EntityResourceList):
+    entity_class = Publisher
+    entity_list_fields = structures.publisher_list
+
+
+def create_views(api):
+    api.add_resource(PublisherResource, '/publisher/<string:entity_gid>',
+                     endpoint='publisher_get_single')
+
+    api.add_resource(
+        EntityAliasResource, '/publisher/<string:entity_gid>/aliases',
+        endpoint='publisher_get_aliases'
+    )
+
+    api.add_resource(
+        EntityDisambiguationResource,
+        '/publisher/<string:entity_gid>/disambiguation',
+        endpoint='publisher_get_disambiguation'
+    )
+
+    api.add_resource(
+        EntityAnnotationResource, '/publisher/<string:entity_gid>/annotation',
+        endpoint='publisher_get_annotation'
+    )
+
+    api.add_resource(PublisherResourceList, '/publisher')

--- a/bbws/revision.py
+++ b/bbws/revision.py
@@ -19,12 +19,21 @@
 from flask import request
 from flask.ext.restful import Resource, abort, fields, marshal, reqparse
 
-from bbschema import (Entity, EntityRevision, PublicationData,
+from bbschema import (Entity, EntityRevision, CreatorData, PublicationData,
+                      EditionData, PublisherData, WorkData,
                       RelationshipRevision, Revision)
 from sqlalchemy.orm.exc import NoResultFound
 
 from . import db, oauth_provider, revision_json, structures
-from .entity import data_mapper
+
+
+data_mapper = {
+    PublicationData: ('publication_data', structures.publication_data),
+    CreatorData: ('creator_data', structures.creator_data),
+    EditionData: ('edition_data', structures.edition_data),
+    PublisherData: ('publisher_data', structures.publisher_data),
+    WorkData: ('work_data', structures.work_data),
+}
 
 
 class RevisionResource(Resource):

--- a/bbws/structures.py
+++ b/bbws/structures.py
@@ -70,7 +70,6 @@ entity.update({
     'aliases_uri': fields.Url('entity_get_aliases', True),
     'disambiguation_uri': fields.Url('entity_get_disambiguation', True),
     'annotation_uri': fields.Url('entity_get_annotation', True),
-    'data_uri': fields.Url('entity_get_data', True),
     'relationships_uri': fields.Url('relationship_get_many', True)
 })
 
@@ -110,7 +109,7 @@ entity_annotation = {
 entity_list = {
     'offset': fields.Integer,
     'count': fields.Integer,
-    'objects': fields.List(fields.Nested(entity))
+    'objects': fields.List(fields.Nested(entity_stub))
 }
 
 
@@ -241,10 +240,30 @@ user_list = {
 
 
 # These fields definitions are specific to BookBrainz
+creator_stub = entity_stub.copy()
+creator_stub.update({
+    'uri': fields.Url('creator_get_single', True)
+})
+
+
+creator = entity.copy()
+creator.update(creator_stub)
+creator.update({
+    'aliases_uri': fields.Url('creator_get_aliases', True),
+    'disambiguation_uri': fields.Url('creator_get_disambiguation', True),
+    'annotation_uri': fields.Url('creator_get_annotation', True),
+    'relationships_uri': fields.Url('relationship_get_many', True)
+})
+
+
+creator_list = {
+    'offset': fields.Integer,
+    'count': fields.Integer,
+    'objects': fields.List(fields.Nested(creator_stub))
+}
 
 
 creator_data = {
-    'entity_data_id': fields.Integer,
     'begin_date': fields.String,
     'begin_date_precision': fields.String,
     'end_date': fields.String,
@@ -261,8 +280,30 @@ creator_data = {
 }
 
 
+publication_stub = entity_stub.copy()
+publication_stub.update({
+    'uri': fields.Url('publication_get_single', True)
+})
+
+
+publication = entity.copy()
+publication.update(publication_stub)
+publication.update({
+    'aliases_uri': fields.Url('publication_get_aliases', True),
+    'disambiguation_uri': fields.Url('publication_get_disambiguation', True),
+    'annotation_uri': fields.Url('publication_get_annotation', True),
+    'relationships_uri': fields.Url('relationship_get_many', True)
+})
+
+
+publication_list = {
+    'offset': fields.Integer,
+    'count': fields.Integer,
+    'objects': fields.List(fields.Nested(publication_stub))
+}
+
+
 publication_data = {
-    'entity_data_id': fields.Integer,
     'publication_type': fields.Nested({
         'publication_type_id': fields.Integer,
         'label': fields.String
@@ -270,8 +311,30 @@ publication_data = {
 }
 
 
+publisher_stub = entity_stub.copy()
+publisher_stub.update({
+    'uri': fields.Url('publisher_get_single', True)
+})
+
+
+publisher = entity.copy()
+publisher.update(publisher_stub)
+publisher.update({
+    'aliases_uri': fields.Url('publisher_get_aliases', True),
+    'disambiguation_uri': fields.Url('publisher_get_disambiguation', True),
+    'annotation_uri': fields.Url('publisher_get_annotation', True),
+    'relationships_uri': fields.Url('relationship_get_many', True)
+})
+
+
+publisher_list = {
+    'offset': fields.Integer,
+    'count': fields.Integer,
+    'objects': fields.List(fields.Nested(publisher_stub))
+}
+
+
 publisher_data = {
-    'entity_data_id': fields.Integer,
     'begin_date': fields.String,
     'begin_date_precision': fields.String,
     'end_date': fields.String,
@@ -284,8 +347,30 @@ publisher_data = {
 }
 
 
+edition_stub = entity_stub.copy()
+edition_stub.update({
+    'uri': fields.Url('edition_get_single', True)
+})
+
+
+edition = entity.copy()
+edition.update(edition_stub)
+edition.update({
+    'aliases_uri': fields.Url('edition_get_aliases', True),
+    'disambiguation_uri': fields.Url('edition_get_disambiguation', True),
+    'annotation_uri': fields.Url('edition_get_annotation', True),
+    'relationships_uri': fields.Url('relationship_get_many', True)
+})
+
+
+edition_list = {
+    'offset': fields.Integer,
+    'count': fields.Integer,
+    'objects': fields.List(fields.Nested(edition_stub))
+}
+
+
 edition_data = {
-    'entity_data_id': fields.Integer,
     'begin_date': fields.String,
     'begin_date_precision': fields.String,
     'end_date': fields.String,
@@ -302,8 +387,30 @@ edition_data = {
 }
 
 
+work_stub = entity_stub.copy()
+work_stub.update({
+    'uri': fields.Url('work_get_single', True)
+})
+
+
+work = entity.copy()
+work.update(work_stub)
+work.update({
+    'aliases_uri': fields.Url('work_get_aliases', True),
+    'disambiguation_uri': fields.Url('work_get_disambiguation', True),
+    'annotation_uri': fields.Url('work_get_annotation', True),
+    'relationships_uri': fields.Url('relationship_get_many', True)
+})
+
+
+work_list = {
+    'offset': fields.Integer,
+    'count': fields.Integer,
+    'objects': fields.List(fields.Nested(work_stub))
+}
+
+
 work_data = {
-    'entity_data_id': fields.Integer,
     'languages': fields.List(fields.Nested({
         'id': fields.Integer,
         'name': fields.String,

--- a/bbws/work.py
+++ b/bbws/work.py
@@ -1,0 +1,62 @@
+# -*- coding: utf8 -*-
+
+# Copyright (C) 2015 Sean Burke
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+""" This module contains the definitions for generic entity and entity-related
+resources.
+"""
+
+from bbschema import Work
+
+from . import structures
+from .entity import (EntityResource, EntityAliasResource,
+                     EntityDisambiguationResource, EntityAnnotationResource,
+                     EntityResourceList)
+
+class WorkResource(EntityResource):
+    entity_class = Work
+    entity_fields = structures.work
+    entity_data_fields = structures.work_data
+
+
+class WorkResourceList(EntityResourceList):
+    entity_class = Work
+    entity_list_fields = structures.work_list
+
+
+def create_views(api):
+    api.add_resource(WorkResource, '/work/<string:entity_gid>',
+                     endpoint='work_get_single')
+
+    api.add_resource(
+        EntityAliasResource, '/work/<string:entity_gid>/aliases',
+        endpoint='work_get_aliases'
+    )
+
+    api.add_resource(
+        EntityDisambiguationResource,
+        '/work/<string:entity_gid>/disambiguation',
+        endpoint='work_get_disambiguation'
+    )
+
+    api.add_resource(
+        EntityAnnotationResource, '/work/<string:entity_gid>/annotation',
+        endpoint='work_get_annotation'
+    )
+
+    api.add_resource(WorkResourceList, '/work')


### PR DESCRIPTION
This addresses #10 by splitting out the /entity endpoint into one endpoint per entity type and flattening entity data and type-specific data into a single structure.

There are still some issues to be addressed in this code. The entity.entity_type = entity_type bit in particular is an ugly hack, but without it, BuildErrors occur and make everyone sad. It would be possible to get rid of this by splitting out the endpoint generation and marshaling code per-entity, but it would also require several new structures. Feedback on the structure welcome.