### PR TITLE
BB-148: Add weight to revision diff

### DIFF
--- a/bbws/structures.py
+++ b/bbws/structures.py
@@ -586,6 +586,7 @@ EDITION_DIFF.update({
     'height': fields.List(fields.Integer(default=None)),
     'width': fields.List(fields.Integer(default=None)),
     'depth': fields.List(fields.Integer(default=None)),
+    'weight': fields.List(fields.Integer(default=None)),
     'language': fields.List(fields.Nested({
         'language_id': fields.Integer(attribute='id'),
         'name': fields.String,


### PR DESCRIPTION
For some reason, the weight option was missing in the EDITION_DIFF .

[BB-148](http://tickets.musicbrainz.org/browse/BB-148)